### PR TITLE
refac: Use Lombok UtilityClass annotation in BaseEndpoint

### DIFF
--- a/apps/provider/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
+++ b/apps/provider/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
@@ -1,8 +1,11 @@
 package com.github.thorlauridsen.controller;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * This class contains the base endpoint constants for the various controllers.
  */
+@UtilityClass
 public class BaseEndpoint {
     public static final String HOTEL_BASE_ENDPOINT = "/hotels";
     public static final String FLIGHT_BASE_ENDPOINT = "/flights";


### PR DESCRIPTION
Use Lombok `UtilityClass` annotation in `BaseEndpoint` because the class is an utility class with only a static constant.