### PR TITLE
refac: Use RestController and RestControllerAdvice for pure REST APIs

### DIFF
--- a/apps/gateway/src/main/java/com/github/thorlauridsen/controller/TravelController.java
+++ b/apps/gateway/src/main/java/com/github/thorlauridsen/controller/TravelController.java
@@ -5,7 +5,7 @@ import com.github.thorlauridsen.service.TravelService;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Travel controller class.
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Controller;
  * The controller is responsible for handling requests for travel details
  * and delegating to the service layer.
  */
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class TravelController implements ITravelController {
 

--- a/apps/provider/src/main/java/com/github/thorlauridsen/controller/FlightController.java
+++ b/apps/provider/src/main/java/com/github/thorlauridsen/controller/FlightController.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Flight controller class.
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Controller;
  * overrides the methods defined in the interface with implementations.
  * The controller is responsible for handling flight requests and delegating to the service layer.
  */
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class FlightController implements IFlightController {
 

--- a/apps/provider/src/main/java/com/github/thorlauridsen/controller/HotelController.java
+++ b/apps/provider/src/main/java/com/github/thorlauridsen/controller/HotelController.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Hotel controller class.
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Controller;
  * overrides the methods defined in the interface with implementations.
  * The controller is responsible for handling hotel requests and delegating to the service layer.
  */
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class HotelController implements IHotelController {
 

--- a/apps/provider/src/main/java/com/github/thorlauridsen/controller/RentalCarController.java
+++ b/apps/provider/src/main/java/com/github/thorlauridsen/controller/RentalCarController.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Rental car controller class.
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Controller;
  * overrides the methods defined in the interface with implementations.
  * The controller is responsible for handling rental car requests and delegating to the service layer.
  */
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class RentalCarController implements IRentalCarController {
 


### PR DESCRIPTION
We should always use the annotations `RestController` and `RestControllerAdvice` for pure REST APIs. This commit updates the Spring Boot annotations.